### PR TITLE
fix: bugs in v7

### DIFF
--- a/src/otrs-popup/otrs-popup.controller.js
+++ b/src/otrs-popup/otrs-popup.controller.js
@@ -32,11 +32,9 @@ export default /* @ngInject */ function (
   OTRS_POPUP_SERVICES,
   OTRS_POPUP_UNIVERSES,
   TICKET_CATEGORIES,
-  // UNIVERSE,
 ) {
   const self = this;
   const OTHER_SERVICE = 'other';
-  const UNIVERSE = 'WEB'; // TODO : remove UNIVERSE
 
   self.loaders = {
     send: false,
@@ -65,10 +63,7 @@ export default /* @ngInject */ function (
     };
 
     self.universes = get(OTRS_POPUP_UNIVERSES, $rootScope.target, OTRS_POPUP_UNIVERSES.EU);
-
-    const standardizedUniverse = UNIVERSE === 'GAMMA' ? 'SUNRISE' : UNIVERSE;
-
-    self.selectedUniverse = includes(['CLOUD', 'DEDICATED'], standardizedUniverse) || !standardizedUniverse ? 'CLOUD_DEDICATED' : standardizedUniverse;
+    [self.selectedUniverse] = self.universes;
 
     self.intervention = {
       serviceName: null,

--- a/src/otrs-popup/otrs-popup.directive.js
+++ b/src/otrs-popup/otrs-popup.directive.js
@@ -62,12 +62,52 @@ export default function () {
       $scope.$on('otrs.popup.open', $scope.open);
       $scope.$on('otrs.popup.close', $scope.close);
 
-      $element.children('.otrs-popup.draggable').one('drag', (event, ui) => {
-        ui.helper.removeClass('otrs-popup-initial');
+      const maximizeWatch = $scope.$watch('status.maximize', () => (
+        $scope.status.maximize
+          ? $element.addClass('maximize')
+          : $element.removeClass('maximize')));
+
+      const minimizeWatch = $scope.$watch('status.minimize', () => (
+        $scope.status.minimize
+          ? $element.addClass('minimize')
+          : $element.removeClass('minimize')));
+
+      const closeWatch = $scope.$watch('status.close', () => (
+        $scope.status.close
+          ? $element.addClass('close')
+          : $element.removeClass('close')));
+
+      $element.addClass('otrs-container');
+      $element.addClass('initial-setting');
+
+      const dragData = {};
+      new Draggable($element[0], { // eslint-disable-line
+        handle: $element.find('#draggableTitle')[0],
+        onDragStart: (element) => {
+          // actualStartPosition is a fix to work-around
+          // the wrong initial height of the pop-up. we
+          // only need it in the first drag operation
+          delete dragData.actualStartPosition;
+          if (element.classList.contains('initial-setting')) {
+            const boundingBox = element.getBoundingClientRect();
+            dragData.actualStartPosition = { x: boundingBox.left, y: boundingBox.top };
+            element.classList.remove('initial-setting');
+          }
+        },
+        limit: (currX, currY, x0, y0) => {
+          const position = (dragData.actualStartPosition
+            ? { x: currX, y: currY - (y0 - dragData.actualStartPosition.y) }
+            : { x: currX, y: currY });
+          // Prevent pop-up to be dragged above the window
+          position.y = position.y < 0 ? 0 : position.y;
+          return position;
+        },
       });
 
-      new Draggable($element[0], { // eslint-disable-line
-        handle: $element.find('#headerPopup')[0],
+      $scope.$on('$destroy', () => {
+        maximizeWatch();
+        minimizeWatch();
+        closeWatch();
       });
     },
   };

--- a/src/otrs-popup/otrs-popup.html
+++ b/src/otrs-popup/otrs-popup.html
@@ -1,23 +1,16 @@
-<div class="draggable otrs-popup otrs-popup-initial"
+<div class="draggable otrs-popup"
      data-draggable
      data-options="{
          containment: 'body',
-         handle: '#headerPopup,
+         handle: '#draggableTitle,
          #contentPopup form'
      }"
      data-ng-class="{
         'minimize': status.minimize,
-        'maximize': status.maximize,
-        'close': status.close
+        'maximize': status.maximize
     }">
     <div>
-        <div class="draggable-header" id="headerPopup">
-            <span data-ng-if="OtrsPopupCtrl.formDetails === 'replacement-disk'"
-                  data-translate="otrs_popup_intervention">
-            </span>
-            <span data-ng-if="OtrsPopupCtrl.formDetails !== 'replacement-disk'"
-                  data-translate="otrs_popup_title">
-            </span>
+        <div class="draggable-header">
             <div class="otrs_popup_tools float-right">
                 <button type="button"
                         aria-label="{{:: 'otrs_popup_icon_minimize' | translate }}"
@@ -34,6 +27,14 @@
                         data-ng-click="close()">
                     <span class="fa fa-close" aria-hidden="true"></span>
                 </button>
+            </div>
+            <div id="draggableTitle" class="draggable-title">
+                <span data-ng-if="OtrsPopupCtrl.formDetails === 'replacement-disk'"
+                    data-translate="otrs_popup_intervention">
+                </span>
+                <span data-ng-if="OtrsPopupCtrl.formDetails !== 'replacement-disk'"
+                    data-translate="otrs_popup_title">
+                </span>
             </div>
         </div>
         <div id="contentPopup">

--- a/src/otrs-popup/otrs-popup.less
+++ b/src/otrs-popup/otrs-popup.less
@@ -3,7 +3,32 @@
 @module-otrs-header-color: #3b4151;
 
 .otrs-container {
-  padding-top: 30px;
+  z-index: 10000;
+  position: fixed !important;
+
+  &.initial-setting,
+  &.minimize {
+    left: auto !important;
+    right: 0 !important;
+    top: auto !important;
+    bottom: 0 !important;
+    height: auto !important;
+  }
+
+  &.minimize {
+    width: auto !important;
+  }
+
+  &.maximize {
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  &.close {
+    display: none !important;
+  }
 }
 
 .otrs-popup {
@@ -11,81 +36,43 @@
   -moz-transition: background-color 500ms linear, height 500ms linear, width 500ms linear;
   -o-transition: background-color 500ms linear, height 500ms linear, width 500ms linear;
   transition: background-color 500ms linear, height 500ms linear, width 500ms linear;
-  position: fixed;
-  width: 30% !important;
-  height: auto !important;
+  width: 30vh !important;
   padding-bottom: 1%;
   background-color: rgba(255, 255, 255, 0.7);
   border: 1px solid rgb(225, 225, 239);
   box-shadow: rgba(0, 0, 0, 0.258824) 0 2px 5px 0;
-  z-index: 10000 !important;
   display: block;
-
-  #headerPopup {
-    position: absolute;
-    top: -30px;
-  }
-
-  &.maximize #headerPopup,
-  &.minimize #headerPopup {
-    position: static;
-  }
 
   #contentPopup {
     height: 100%;
     overflow-y: auto;
     padding: 0 20px;
+    max-height: 95vh;
   }
 
-  #contentPopup form {
+  .draggable-header {
+    width: 100%;
     cursor: move;
+    margin-left: 0 !important;
+    height: 30px;
+    text-align: left;
+    line-height: 30px;
+    color: #efefef;
+    background: @module-otrs-header-color;
+  }
+
+  &.maximize #contentPopup {
+    max-height: none;
   }
 
   &.minimize {
     height: 30px !important;
-    bottom: 0 !important;
-    right: 0 !important;
-    left: auto !important;
-    top: auto !important;
   }
 
   &.maximize {
     height: 100% !important;
     width: 100% !important;
-    top: 0 !important;
-    left: 0 !important;
     overflow: auto;
-  }
-
-  .draggable-body,
-  .draggable-footer,
-  .draggable-header, {
-    width: 100%;
-  }
-
-  .draggable-body {
-    -webkit-transition: height 500ms linear;
-    -moz-transition: height 500ms linear;
-    -o-transition: height 500ms linear;
-    transition: height 500ms linear;
-    height: 100%;
-    width: 100%;
-    overflow: auto;
-  }
-
-  &.minimize .draggable-body {
-    height: 0;
-    overflow: hidden;
-  }
-
-  &.maximize .draggable-body {
-    height: 100%;
-    width: 100%;
-    overflow: auto;
-  }
-
-  &.close {
-    display: none;
   }
 
   &:hover,
@@ -98,18 +85,12 @@
     background-color: rgba(255, 255, 255, 0.6);
   }
 
-  .draggable-header {
-    cursor: move;
-    margin-left: 0 !important;
-    height: 30px;
-    text-align: left;
-    line-height: 30px;
-    color: #efefef;
-    background: @module-otrs-header-color;
-  }
-
   .draggable-header span {
     margin-left: 5px;
+  }
+
+  .draggable-header .draggable-title {
+    overflow: hidden;
   }
 
   .draggable-header a.pull-right {
@@ -145,21 +126,19 @@
   }
 }
 
-.otrs-popup-initial {
-  bottom: 0;
-  right: 0;
-}
-
 @media (max-width: @screen-md) {
   .otrs-popup {
-    width: 98% !important;
-    height: 90% !important;
+    width: 98vw !important;
+
+    #contentPopup {
+      max-height: 86vh;
+    }
   }
 }
 
 @media (min-width: @screen-md) {
   .otrs-popup {
-    width: 30% !important;
+    width: 30vw !important;
   }
 }
 
@@ -177,14 +156,20 @@
 
 @media screen and (max-width: @screen-xs-max) and (orientation: portrait) {
   .otrs-popup {
-    width: 75% !important;
-    height: 75% !important;
+    width: 98vw !important;
+
+    #contentPopup {
+      max-height: 86vh;
+    }
   }
 }
 
 @media screen and (max-width: @screen-xs-max) and (orientation: landscape) {
   .otrs-popup {
-    width: 55% !important;
-    height: 70% !important;
+    width: 55vw !important;
+
+    #contentPopup {
+      max-height: 86vh;
+    }
   }
 }

--- a/src/otrs-popup/otrs-popup.service.js
+++ b/src/otrs-popup/otrs-popup.service.js
@@ -39,7 +39,7 @@ export default class OtrsPopupService {
   }
 
   toggle() {
-    if ($('[data-otrs-popup] .draggable').hasClass('close')) {
+    if ($('[data-otrs-popup]').hasClass('close')) {
       this.open();
       this.opened = true;
       this.$rootScope.$broadcast('otrs.popup.opened');

--- a/src/otrs-popup/translations/Messages_cs_CZ.xml
+++ b/src/otrs-popup/translations/Messages_cs_CZ.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Server-Housing </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Webhostingová služba</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">IP Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">IP Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licence CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licence cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licence DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_de_DE.xml
+++ b/src/otrs-popup/translations/Messages_de_DE.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Server-Housing </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Webhosting</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">IP-Loadbalancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">IP-Loadbalancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux Lizenz</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel Lizenz</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin Lizenz</translation>

--- a/src/otrs-popup/translations/Messages_en_ASIA.xml
+++ b/src/otrs-popup/translations/Messages_en_ASIA.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting service</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Load balancer IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Load balancer IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux licence</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel licence</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin licence</translation>

--- a/src/otrs-popup/translations/Messages_en_AU.xml
+++ b/src/otrs-popup/translations/Messages_en_AU.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting service</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Load balancer IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Load balancer IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux licence</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel licence</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin licence</translation>

--- a/src/otrs-popup/translations/Messages_en_CA.xml
+++ b/src/otrs-popup/translations/Messages_en_CA.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting service</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Load balancer IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Load balancer IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux licence</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel licence</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin licence</translation>

--- a/src/otrs-popup/translations/Messages_en_GB.xml
+++ b/src/otrs-popup/translations/Messages_en_GB.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting service</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Load balancer IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Load balancer IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux licence</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel licence</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin licence</translation>

--- a/src/otrs-popup/translations/Messages_en_SG.xml
+++ b/src/otrs-popup/translations/Messages_en_SG.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting service</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Load balancer IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Load balancer IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux licence</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel licence</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin licence</translation>

--- a/src/otrs-popup/translations/Messages_en_US.xml
+++ b/src/otrs-popup/translations/Messages_en_US.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Hosted Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting service</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Load balancer IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Load balancer IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux license</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel license</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin license</translation>

--- a/src/otrs-popup/translations/Messages_es_ES.xml
+++ b/src/otrs-popup/translations/Messages_es_ES.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Servidor en housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">IP Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">IP Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licencia CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licencia cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licencia DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_es_US.xml
+++ b/src/otrs-popup/translations/Messages_es_US.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Servidor en housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Web hosting</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Ip Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Ip Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licencia CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licencia cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licencia DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_fi_FI.xml
+++ b/src/otrs-popup/translations/Messages_fi_FI.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing-palvelin</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Webhotelli</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">IP-kuormantasaaja</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">IP-kuormantasaaja</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Cloud Linux -lisenssi</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">cPanel-lisenssi</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin-lisenssi</translation>

--- a/src/otrs-popup/translations/Messages_fr_CA.xml
+++ b/src/otrs-popup/translations/Messages_fr_CA.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Hébergement de serveurs</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Cloud Privé</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Hébergement web</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Équilibreur de charge IP</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Équilibreur de charge IP</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licence CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licence cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licence DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_fr_FR.xml
+++ b/src/otrs-popup/translations/Messages_fr_FR.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="otrs_detail_title" qtlid="245181">Retour à la liste de vos tickets</translation>
+   <translation id="otrs_detail_title">Assistance - Fil de discussion</translation>
    <translation id="otrs_detail_title2" qtlid="228774">- ticket {0}</translation>
    <translation id="otrs_detail_title3_open" qtlid="228787">- (En cours)</translation>
    <translation id="otrs_detail_title3_closed" qtlid="228800">- (Fermé)</translation>
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Serveur Housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Hébergement web</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Ip Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Ip Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licence CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licence_cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licence DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_it_IT.xml
+++ b/src/otrs-popup/translations/Messages_it_IT.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Server Housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Dedicated Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Hosting web</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Ip Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Ip Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licenza CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licenza_cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licenza DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_lt_LT.xml
+++ b/src/otrs-popup/translations/Messages_lt_LT.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Servis Housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Svetainių talpinimas</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Ip Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Ip Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux lincencija</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licence_cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin lincencija</translation>

--- a/src/otrs-popup/translations/Messages_nl_NL.xml
+++ b/src/otrs-popup/translations/Messages_nl_NL.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Housing server </translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Webhosting</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">IP Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">IP Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">CloudLinux licentie</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">_cPanel licentie</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">DirectAdmin licentie</translation>

--- a/src/otrs-popup/translations/Messages_pl_PL.xml
+++ b/src/otrs-popup/translations/Messages_pl_PL.xml
@@ -97,7 +97,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Serwer Housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Hosting WWW</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">IP Load Balancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">IP Load Balancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licencja CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">Licencja cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licencja DirectAdmin</translation>

--- a/src/otrs-popup/translations/Messages_pt_PT.xml
+++ b/src/otrs-popup/translations/Messages_pt_PT.xml
@@ -98,7 +98,7 @@
    <translation id="otrs_service_category_DEDICATED_HOUSING" qtlid="371476">Servidor Housing</translation>
    <translation id="otrs_service_category_DEDICATED_CLOUD" qtlid="20131">Private Cloud</translation>
    <translation id="otrs_service_category_HOSTING_WEB" qtlid="219979">Alojamento Web</translation>
-   <translation id="otrs_service_category_IP_LOADBALANCING" qtlid="219992">Ip LoadBalancer</translation>
+   <translation id="otrs_service_category_LOAD_BALANCER" qtlid="219992">Ip LoadBalancer</translation>
    <translation id="otrs_service_category_LICENCE_CLOUD_LINUX" qtlid="220005">Licença CloudLinux</translation>
    <translation id="otrs_service_category_LICENCE_CPANEL" qtlid="220018">licenca_cPanel</translation>
    <translation id="otrs_service_category_LICENCE_DIRECT_ADMIN" qtlid="220031">Licença DirectAdmin</translation>


### PR DESCRIPTION
Close MBE-83 & MBE-90

Since the draggable library is being used, the basic implementation of the pop-up has to be changed and this is done in this PR.

The following issues are fixed:
1. Dragging the pop-up over the navbar hides the pop-up
2. Dragging the pop-up lower makes the scroll for the page appear (since it was absolutely positioned)
3. Once the user drags the pop-up outside the top of the window, there is no way to drag it again
4. No scrollbar in the pop-up, if the height of the pop-up exceeds the window height
5. Translation does not substitute the parameters properly